### PR TITLE
Portfolio: feature Agent Tracking Portal (now public)

### DIFF
--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -88,14 +88,11 @@ const FEATURED: FeaturedProject[] = [
     links: [{ label: "GitHub", href: "https://github.com/tstanmay13/claude-code-search-" }],
   },
   {
-    title: "This site",
+    title: "Agent Tracking Portal",
     description:
-      "Portfolio + 33-game retro arcade with realtime multiplayer (lobbies, room codes, presence) over Supabase channels.",
-    tech: ["Next.js", "React 19", "Supabase Realtime"],
-    links: [
-      { label: "GitHub", href: "https://github.com/tstanmay13/tanmay-singh-landing" },
-      { label: "Arcade", href: "/games" },
-    ],
+      "One dashboard for every AI agent working for you: normalizes Claude Code, Devin, and Slack sessions through a single zod-typed contract with idempotent dedup. Answers one question: which agents need me right now? 82 tests.",
+    tech: ["TypeScript", "Fastify", "SQLite", "SSE"],
+    links: [{ label: "GitHub", href: "https://github.com/tstanmay13/agent-tracking-portal" }],
   },
 ];
 


### PR DESCRIPTION
agent-tracking-portal went public today after an audit (no secrets in history, work references genericized, CI added — 82 tests green on Node 20/22). Replaces the self-referential 'This site' FEATURED card; the site remains in the GitHub grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)