### PR TITLE
Slim nav + restore classic hero stats (exp/projects/commits)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -269,6 +269,7 @@ function LoadoutRow({ slot, items }: { slot: string; items: string }) {
 export default function Home() {
   const [mounted, setMounted] = useState(false);
   const [contributions, setContributions] = useState<number | null>(null);
+  const [projectCount, setProjectCount] = useState<number | null>(null);
   const aboutRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
@@ -276,7 +277,7 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    // If the API fails we show nothing rather than a made-up number.
+    // If an API fails we keep the placeholder rather than a made-up number.
     const fetchContributions = async () => {
       try {
         const response = await fetch("/api/github-contributions");
@@ -289,18 +290,37 @@ export default function Home() {
         console.error("Failed to fetch GitHub contributions:", error);
       }
     };
+    const fetchProjects = async () => {
+      try {
+        const response = await fetch("/api/portfolio/repos");
+        if (!response.ok) throw new Error("Failed to fetch repos");
+        const data = await response.json();
+        setProjectCount(data.repos?.length ?? null);
+      } catch {
+        // leave null
+      }
+    };
     fetchContributions();
+    fetchProjects();
   }, []);
 
   const scrollToAbout = useCallback(() => {
     aboutRef.current?.scrollIntoView({ behavior: "smooth" });
   }, []);
 
-  // Real numbers only — see /games, radiordle.org, github.com/tstanmay13.
+  // The classic trio — live numbers where possible, placeholders while loading.
   const heroStats: Stat[] = [
-    { label: "GAMES IN THE ARCADE", value: "33", icon: "#" },
-    { label: "DAILY PLAYERS", value: "1K+", icon: "*" },
-    { label: "MERGED PRS / YR", value: "400+", icon: ">" },
+    { label: "YRS EXP", value: "3+", icon: ">" },
+    {
+      label: "PROJECTS",
+      value: projectCount !== null ? `${projectCount}` : "...",
+      icon: "#",
+    },
+    {
+      label: "COMMITS",
+      value: contributions !== null ? contributions.toLocaleString() : "...",
+      icon: "*",
+    },
   ];
 
   if (!mounted) {

--- a/src/components/PixelNav.tsx
+++ b/src/components/PixelNav.tsx
@@ -28,17 +28,17 @@ export default function PixelNav() {
 
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 pixel-nav">
-      <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
+      <div className="max-w-6xl mx-auto px-4 py-2 flex items-center justify-between">
         {/* Logo */}
         <Link
           href="/"
           className="flex items-center gap-2 group"
           data-interactive
         >
-          <span className="text-2xl pixel-text font-bold text-[var(--color-accent)] group-hover:animate-pixel-bounce">
+          <span className="text-xl pixel-text font-bold text-[var(--color-accent)] group-hover:animate-pixel-bounce">
             TS
           </span>
-          <span className="hidden sm:inline text-sm text-[var(--color-text-secondary)] pixel-text">
+          <span className="hidden sm:inline text-xs text-[var(--color-text-secondary)] pixel-text">
             tanmay singh
           </span>
         </Link>
@@ -48,7 +48,7 @@ export default function PixelNav() {
           {navLinks.map((link) => {
             const isActive = !link.external && (pathname === link.href ||
               (link.href !== "/" && pathname.startsWith(link.href)));
-            const className = `px-4 py-2 text-sm pixel-text transition-all duration-200 border-2 ${
+            const className = `px-3 py-1.5 text-xs pixel-text transition-all duration-200 border-2 ${
               isActive
                 ? "border-[var(--color-accent)] text-[var(--color-accent)] bg-[var(--color-accent)]/10"
                 : "border-transparent text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:border-[var(--color-border)]"
@@ -82,7 +82,7 @@ export default function PixelNav() {
           <button
             onClick={toggleTheme}
             data-interactive
-            className="ml-3 px-3 py-2 border-2 border-[var(--color-border)] text-[var(--color-text)] hover:border-[var(--color-accent)] transition-all duration-200 pixel-text text-sm"
+            className="ml-3 px-2.5 py-1.5 border-2 border-[var(--color-border)] text-[var(--color-text)] hover:border-[var(--color-accent)] transition-all duration-200 pixel-text text-xs"
             aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
           >
             {theme === "dark" ? "☀️ DAY" : "🌙 NIGHT"}


### PR DESCRIPTION
Owner feedback: nav read oversized and the PR-count metrics felt off-brand for the hero. Links/toggle to text-xs with tighter padding; stats back to the classic trio with live GitHub numbers (placeholders while loading, nothing fabricated on failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)